### PR TITLE
Updated the project to target .NET Standard 1.3

### DIFF
--- a/src/ArangoDB.AspNetCore.Identity/ArangoDB.AspNetCore.Identity.nuspec
+++ b/src/ArangoDB.AspNetCore.Identity/ArangoDB.AspNetCore.Identity.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
     <id>$id$</id>
     <version>$version$</version>
@@ -12,9 +12,9 @@
     <releaseNotes>Initial production release</releaseNotes>
     <copyright>Copyright 2016</copyright>
     <tags>ArangoDB AspNetCore Identity AspNet</tags>
-	<dependencies>
+    <dependencies>
       <dependency id="Microsoft.AspNetCore.Identity" version="1.0.0" />
-	  <dependency id="ArangoDB.Client" version="0.7.31" />
+      <dependency id="ArangoDB.Client" version="0.7.50" />
     </dependencies>
   </metadata>
 </package>

--- a/src/ArangoDB.AspNetCore.Identity/UserStore.Methods.cs
+++ b/src/ArangoDB.AspNetCore.Identity/UserStore.Methods.cs
@@ -433,7 +433,7 @@ namespace ArangoDB.AspNetCore.Identity
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
 
-            if (!user.Roles.Contains(role, StringComparer.InvariantCultureIgnoreCase))
+            if (!user.Roles.Contains(role, StringComparer.OrdinalIgnoreCase))
                 user.Roles.Add(role);
 
             return Task.FromResult(0);
@@ -470,7 +470,7 @@ namespace ArangoDB.AspNetCore.Identity
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
 
-            return Task.FromResult(user.Roles.Contains(role, StringComparer.InvariantCultureIgnoreCase));
+            return Task.FromResult(user.Roles.Contains(role, StringComparer.OrdinalIgnoreCase));
         }
 
         public async Task<IList<TUser>> GetUsersInRoleAsync(string roleName, CancellationToken cancellationToken)
@@ -501,7 +501,7 @@ namespace ArangoDB.AspNetCore.Identity
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
 
-            user.Roles.RemoveAll(r => string.Equals(r, role, StringComparison.InvariantCultureIgnoreCase));
+            user.Roles.RemoveAll(r => string.Equals(r, role, StringComparison.OrdinalIgnoreCase));
 
             return Task.FromResult(0);
         }

--- a/src/ArangoDB.AspNetCore.Identity/project.json
+++ b/src/ArangoDB.AspNetCore.Identity/project.json
@@ -2,14 +2,14 @@
   "authors": [ "Actias" ],
   "dependencies": {
     "Microsoft.AspNetCore.Identity": "1.0.0",
-    "ArangoDB.Client": "0.7.31"
+    "ArangoDB.Client": "0.7.50"
   },
 
   "title": "ArangoDB.AspNetCore.Identity",
   "description": "ASP.NET Core Identity provider that uses ArangoDB for storage",
 
   "frameworks": {
-    "net461": {}
+    "netstandard1.3": {}
   },
 
   "packOptions": {


### PR DESCRIPTION
It looks like the ArangoDB Client library was updated to support .NET Core as of 0.7.50. I've updated this library to support .NET Standard 1.3 which allows .NET Core as well as at least .NET 4.6.

Resolves issue #1 